### PR TITLE
Added Cooking Skill

### DIFF
--- a/BoneAppetit.sln
+++ b/BoneAppetit.sln
@@ -5,6 +5,18 @@ VisualStudioVersion = 16.0.31019.35
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoneAppetit", "JotunnModStub\BoneAppetit.csproj", "{DEAF4438-8089-40ED-8175-398E1261D45B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{824C962E-F696-4D23-9C71-06B2BEA8774D}"
+	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		BoneAppetit asset_code stuff.txt = BoneAppetit asset_code stuff.txt
+		DoPrebuild.props = DoPrebuild.props
+		LICENSE = LICENSE
+		publish.ps1 = publish.ps1
+		README.MD = README.MD
+		setup.txt = setup.txt
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/JotunnModStub/BoneAppetit.csproj
+++ b/JotunnModStub/BoneAppetit.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JotunnLib.2.0.12\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.0.12\build\JotunnLib.props')" />
+  <Import Project="..\packages\JotunnLib.2.2.5\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.2.5\build\JotunnLib.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -41,32 +41,41 @@
   <PropertyGroup>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.4.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\HarmonyX.2.4.2\lib\net45\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.5.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HarmonyX.2.5.4\lib\net45\0Harmony.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Jotunn, Version=2.0.12.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JotunnLib.2.0.12\lib\net462\Jotunn.dll</HintPath>
+    <Reference Include="Jotunn, Version=2.2.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JotunnLib.2.2.5\lib\net462\Jotunn.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Cecil, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.3\lib\net40\Mono.Cecil.dll</HintPath>
+    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.3\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.3\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.3\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="MonoMod, Version=21.6.21.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MonoMod.21.6.21.1\lib\net40\MonoMod.exe</HintPath>
+    <Reference Include="MonoMod, Version=21.8.19.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.21.8.19.1\lib\net40\MonoMod.exe</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="MonoMod.RuntimeDetour, Version=21.6.21.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MonoMod.RuntimeDetour.21.6.21.1\lib\net40\MonoMod.RuntimeDetour.dll</HintPath>
+    <Reference Include="MonoMod.RuntimeDetour, Version=21.8.19.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.RuntimeDetour.21.8.19.1\lib\net40\MonoMod.RuntimeDetour.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="MonoMod.Utils, Version=21.6.21.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MonoMod.Utils.21.6.21.1\lib\net40\MonoMod.Utils.dll</HintPath>
+    <Reference Include="MonoMod.Utils, Version=21.8.19.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.Utils.21.8.19.1\lib\net40\MonoMod.Utils.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -78,8 +87,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BoneAppetit.cs" />
+    <Compile Include="Patch.cs" />
     <Compile Include="Properties\IgnoreAccessModifiers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SE_CheffHat.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -117,6 +128,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\JotunnLib.2.0.12\build\JotunnLib.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JotunnLib.2.0.12\build\JotunnLib.props'))" />
+    <Error Condition="!Exists('..\packages\JotunnLib.2.2.5\build\JotunnLib.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JotunnLib.2.2.5\build\JotunnLib.props'))" />
   </Target>
 </Project>

--- a/JotunnModStub/BoneAppetit.csproj.digitalroot
+++ b/JotunnModStub/BoneAppetit.csproj.digitalroot
@@ -1,0 +1,429 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--<Import Project="..\packages\JotunnLib.2.2.3\build\JotunnLib.props" Condition="Exists('..\packages\JotunnLib.2.2.3\build\JotunnLib.props')" />-->
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DEAF4438-8089-40ED-8175-398E1261D45B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BoneAppetit</RootNamespace>
+    <AssemblyName>BoneAppetit</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>
+    </DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="0Harmony, Version=2.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\0Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_googleanalytics, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_googleanalytics.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_guiutils, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_guiutils.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_lux, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_lux.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_postprocessing, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_postprocessing.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_simplemeshcombine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_simplemeshcombine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_steamworks, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_steamworks.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_sunshafts, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_sunshafts.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_utils, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_utils.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="assembly_valheim, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\assembly_valheim.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="bepinex, Version=5.4.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\bepinex.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Jotunn, Version=2.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\JotunnLib.2.2.3\lib\net462\Jotunn.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoMod, Version=21.8.19.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.21.8.19.1\lib\net40\MonoMod.exe</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoMod.RuntimeDetour, Version=21.8.19.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.RuntimeDetour.21.8.19.1\lib\net40\MonoMod.RuntimeDetour.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoMod.Utils, Version=21.8.19.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.Utils.21.8.19.1\lib\net40\MonoMod.Utils.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.Linq">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.DataSetExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\Microsoft.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.6.2\System.Xml.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AccessibilityModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.AccessibilityModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.AIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AndroidJNIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.AndroidJNIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.AnimationModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ARModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.ARModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.AssetBundleModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.AudioModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ClothModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.ClothModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ClusterInputModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.ClusterInputModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ClusterRendererModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.ClusterRendererModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CrashReportingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.CrashReportingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.DirectorModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.DirectorModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.DSPGraphModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.DSPGraphModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.GameCenterModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.GameCenterModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.GridModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.GridModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.HotReloadModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.HotReloadModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.ImageConversionModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.InputLegacyModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.InputModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.InputModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.JSONSerializeModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.LocalizationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.LocalizationModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.PerformanceReportingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.PerformanceReportingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.Physics2DModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.Physics2DModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.PhysicsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ProfilerModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.ProfilerModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.ScreenCaptureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.ScreenCaptureModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SharedInternalsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.SharedInternalsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SpriteMaskModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.SpriteMaskModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SpriteShapeModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.SpriteShapeModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.StreamingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.StreamingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SubstanceModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.SubstanceModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.SubsystemsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.SubsystemsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TerrainModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.TerrainModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TerrainPhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextCoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.TextCoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TilemapModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.TilemapModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TLSModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.TLSModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UIElementsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UmbraModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UmbraModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UNETModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UNETModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityAnalyticsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityConnectModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UnityConnectModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityTestProtocolModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestAudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.VehiclesModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.VehiclesModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.VFXModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.VFXModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.VideoModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.VideoModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.VRModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.VRModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.WindModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.WindModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.XRModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pfhoenix.Valheim.ModProjectReferences.1.0.6\lib\net46\UnityEngine.XRModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BoneAppetit.cs" />
+    <Compile Include="Patch.cs" />
+    <Compile Include="Properties\IgnoreAccessModifiers.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SE_CheffHat.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="grill" />
+    <EmbeddedResource Include="customfood" />
+    <None Include="packages.config" />
+    <None Include="Package\README.md" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Package\plugins\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Package\manifest.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Package\icon.png" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="JotunnPostBuildTaskWin" Condition="'$(OS)' == 'Windows_NT'">
+    <!--<Exec Command="powershell.exe -ExecutionPolicy RemoteSigned -File &quot;$(SolutionDir)publish.ps1&quot; -Target &quot;$(ConfigurationName)&quot; -TargetPath &quot;$(TargetDir.TrimEnd('\'))&quot; -TargetAssembly &quot;$(TargetFileName)&quot; -ValheimPath &quot;$(VALHEIM_INSTALL.TrimEnd('\'))&quot; -ProjectPath &quot;$(ProjectDir.TrimEnd('\'))&quot; " />-->
+  </Target>
+  <!--<PropertyGroup>
+    <BuildDependsOn>
+      $(BuildDependsOn);
+      JotunnPostBuildTaskWin
+    </BuildDependsOn>
+  </PropertyGroup>-->
+  <!--<Target Name="EnsureEnvironmentPropsImport" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project needs a Environment.props file with the path to your Valheim installation. See https://github.com/Valheim-Modding/JotunnModStub. {0} is missing.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)Environment.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)Environment.props'))" />
+  </Target>-->
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\JotunnLib.2.2.3\build\JotunnLib.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JotunnLib.2.2.3\build\JotunnLib.props'))" />
+  </Target>
+</Project>

--- a/JotunnModStub/Patch.cs
+++ b/JotunnModStub/Patch.cs
@@ -1,0 +1,80 @@
+﻿using HarmonyLib;
+using JetBrains.Annotations;
+using System;
+
+namespace BoneAppetit
+{
+  /// <summary>
+  /// Harmony Patches
+  /// </summary>
+  public static class Patch
+  {
+    #region CookingStation
+
+    /// <summary>
+    /// Patch the cooking station
+    /// </summary>
+    [HarmonyPatch(typeof(CookingStation))]
+    public static class PatchCookingStation
+    {
+      /// <summary>
+      /// Patch the CookItem method
+      /// </summary>
+      /// <param name="__result">Was item placed on the cooking station successfully?</param>
+      [HarmonyPostfix]
+      [HarmonyPatch(nameof(CookingStation.CookItem))]
+      [HarmonyPriority(Priority.Normal)]
+      [UsedImplicitly]
+      public static void Postfix(ref bool __result)
+      {
+        try
+        {
+          Boneappetit.BoneAppetit.Instance.OnCookingStationCookItem(ref __result);
+        }
+        catch (Exception e)
+        {
+          Jotunn.Logger.LogError(e);
+        }
+      }
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Patch the Players Inventory
+    /// </summary>
+    [HarmonyPatch(typeof(Inventory), nameof(Inventory.AddItem), typeof(string), typeof(int), typeof(int), typeof(int), typeof(long), typeof(string))]
+    public static class PatchInventory
+    {
+      /// <summary>
+      /// Patch the AddItem method
+      /// </summary>
+      /// <param name="name">Name of the item</param>
+      /// <param name="stack">Stack size</param>
+      /// <param name="quality">Quality level</param>
+      /// <param name="variant">Variant to use</param>
+      /// <param name="crafterID">Id of the player who is crafting</param>
+      /// <param name="crafterName">Name of the player who is crafting</param>
+      [HarmonyPostfix]
+      [HarmonyPriority(Priority.Normal)]
+      [UsedImplicitly]
+      public static void Postfix(string name, int stack, int quality, int variant, long crafterID, string crafterName)
+      {
+        try
+        {
+          Jotunn.Logger.LogDebug($"PatchInventoryPostfix");
+          if (Player.m_localPlayer == null)
+          {
+            Jotunn.Logger.LogDebug("Player is null");
+            return;
+          }
+          Boneappetit.BoneAppetit.Instance.OnInventoryAddItemPostFix(name, stack, quality, variant, crafterID, crafterName);
+        }
+        catch (Exception e)
+        {
+          Jotunn.Logger.LogError(e);
+        }
+      }
+    }
+  }
+}

--- a/JotunnModStub/SE_CheffHat.cs
+++ b/JotunnModStub/SE_CheffHat.cs
@@ -1,0 +1,105 @@
+﻿using JetBrains.Annotations;
+using System.Collections.Generic;
+using Random = UnityEngine.Random;
+
+namespace Boneappetit
+{
+  /// <summary>
+  /// Chef Hat Status Effect.
+  /// </summary>
+  [UsedImplicitly]
+  // ReSharper disable once InconsistentNaming
+  public class SE_CheffHat : SE_Stats
+  {
+    /// <summary>
+    /// ctor
+    /// </summary>
+    public SE_CheffHat()
+    {
+      name = "rkCookingSkillStatusEffect";
+      m_name = "Cooking Bonus";
+      m_raiseSkill = BoneAppetit.Instance.rkCookingSkill;
+      m_raiseSkillModifier = BoneAppetit.Instance.HatXpGain.Value;
+      m_startMessageType = MessageHud.MessageType.Center;
+      m_stopMessageType = MessageHud.MessageType.Center;
+      SetMessages();
+    }
+
+    /// <summary>
+    /// Randomly sets the status effect start and stop message
+    /// </summary>
+    private void SetMessages()
+    {
+      if (!BoneAppetit.Instance.HatSEMessage.Value)
+      {
+        if (string.IsNullOrEmpty(m_startMessage) && string.IsNullOrEmpty(m_stopMessage)) return;
+        {
+          m_startMessage = string.Empty;
+          m_stopMessage = string.Empty;
+          return;
+        }
+      }
+
+      var current = m_startMessage;
+      do
+      {
+        m_startMessage = RandomJuliaChildPhrase.GetRandomPhrase();
+      } while (m_startMessage.Equals(m_stopMessage) || m_startMessage.Equals(current));
+
+      current = m_stopMessage;
+      do
+      {
+        m_stopMessage = RandomJuliaChildPhrase.GetRandomPhrase();
+      } while (m_stopMessage.Equals(m_startMessage) || m_stopMessage.Equals(current));
+    }
+
+    #region Overrides of SE_Stats
+
+    /// <inheritdoc />
+    public override void Setup(Character character)
+    {
+      SetMessages();
+      base.Setup(character);
+    }
+
+    #endregion
+  }
+
+  /// <summary>
+  /// Random Julia Child Phrases
+  /// </summary>
+  public static class RandomJuliaChildPhrase
+  {
+    /// <summary>
+    /// List of Julia Child Phrases
+    /// </summary>
+    private static readonly List<string> PhrasesList = new List<string>
+    {
+      "No one is born a great cook, one learns by doing. - Julia Child"
+      , "You don’t have to cook fancy or complicated masterpieces, just good food from fresh ingredients. - Julia Child"
+      , "People who love to eat are always the best people. - Julia Child"
+      , "Cooking well doesn’t mean cooking fancy. - Julia Child"
+      , "The only time to eat diet food is while you’re waiting for the steak to cook. - Julia Child"
+      , "Until I discovered cooking, I was never really interested in anything. - Julia Child"
+      , "You are the butter to my bread, and the breath to my life. - Julia Child"
+      , "Fat gives things flavor. - Julia Child"
+      , "If you’re afraid of butter, use cream. - Julia Child"
+      , "I was 32 when I started cooking; up until then, I just ate. - Julia Child"
+      , "A party without cake is just a meeting. - Julia Child"
+      , "The only real stumbling block is fear of failure. In cooking you’ve got to have a what-the-hell attitude. - Julia Child"
+      , "In France, cooking is a serious art form and a national sport. - Julia Child"
+      , "You are the BOSS of that dough. - Julia Child"
+      , "with enough butter anything is good. - Julia Child"
+      , "Usually, one’s cooking is better than one thinks it is. - Julia Child"
+    };
+
+    /// <summary>
+    /// Gets a random Julia Child Phrase.
+    /// </summary>
+    /// <returns>Random Julia Child Phrase</returns>
+    public static string GetRandomPhrase()
+    {
+      return PhrasesList[Random.Range(0, PhrasesList.Count -1)];
+    }
+  }
+}

--- a/JotunnModStub/packages.config.digitalroot
+++ b/JotunnModStub/packages.config.digitalroot
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HarmonyX" version="2.5.4" targetFramework="net462" />
-  <package id="JotunnLib" version="2.2.5" targetFramework="net462" />
+  <package id="JotunnLib" version="2.2.3" targetFramework="net462" />
   <package id="Mono.Cecil" version="0.11.4" targetFramework="net462" />
   <package id="MonoMod" version="21.8.19.1" targetFramework="net462" />
   <package id="MonoMod.RuntimeDetour" version="21.8.19.1" targetFramework="net462" />
   <package id="MonoMod.Utils" version="21.8.19.1" targetFramework="net462" />
+  <package id="Pfhoenix.Valheim.ModProjectReferences" version="1.0.6" targetFramework="net462" />
 </packages>

--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@ Description revamp coming soon!
     - release includes 2 food crafting stations that require a fire underneath to cook on, and 5 new food items, one for each biome.
 - v. 1.0.1  
     - hotfix for those not using V+
-- v. 1.1.0 	
+- v. 1.1.0  
     - fix for the grill making it difficult to load the fire underneath
     - fix for Fried Lox not auto picking up
     - 5 new foods. Pancakes, Smoked Fish, Bacon, Coffee, and Pizza
@@ -28,7 +28,7 @@ Description revamp coming soon!
     - Redid all "Flavor" text
         
 ### `MAKE SURE YOU HAVE THE MOD AND CONFIG ON THE SERVER FOR THE SERVER SYNC TO WORK`
-	
+    
 - v. 2.0.1
     - Fixed "CloudBerry" so we can have CAKE! (Big thanks to PROXiCiDE for pointing this out to me)
 - v. 3.0.0
@@ -45,6 +45,22 @@ Description revamp coming soon!
 - v. 3.0.2
     - Load order fix
     - maybe fix for prep table fire (hopefully)
+- v. 3.1.0
+    - Added Cooking Skill
+      - Gain XP when cooking at a **Cooking Station**, or cooking a Consumable at the **rk_griddle**, **rk_grill**, **rk_prep** or **piece_cauldron**. Each level of cooking skill adds a 1% chance to craft an additional consumable. after lvl 25, your total cooking level is divided by 4 and the results is the % chance to crafted a 2nd additional consumable. 
+      - e.g. At level 100, there is a 100% chance to craft an additional consumable and 25% chance to craft a 2nd additional consumable on top of that. At level 100 a food that crafts in stacks of x5, if lucky could output 7 total items.
+      - Set **CookingSkillEnable** = false to disable.
+    - Added SE_CheffHat
+      - Improves Cooking Skill XP Earned while wearing the Chef Hat. 
+      - Set **HatXpGain** = 1 to disable.
+      - Taking the Chef Hat on and off displays a random Julia Child's quote. 
+        - Displaying this message can be disabled by setting **HatSEMessage** to false.
+    - Added Configs
+      - CookingSkillEnable (server synced, enforced)
+      - BonusWhenCookingEnabled (server synced, enforced)
+      - HatXpGain (server synced, enforced)
+      - HatSEMessage (local)
+    - Added NexusId for update notice mod.
 
 
 ## Installation:
@@ -52,7 +68,7 @@ Description revamp coming soon!
 Place the dll in the plugins folder, load the game to the start screen and *quit*. This will generate the config for the first time.
 
 **Known Issue:** Food *WILL NOT* show up to be crafted the very first time you load in after install and config generation. **please generate the config, quit and restart.**
-			
+            
 
 **Note:** This mod requires JVL (Jotunn the Valheim Lib) and it's dependent HookGenPatcher, it will not work without it.
 
@@ -73,138 +89,138 @@ Prep Table | New station in v3.0.0, all ice cream was moved here. requires Tin
 ### v. 1.0.0 - Initial Release
 
 - Pork Rinds 
-	- pork
-	- scraps
+    - pork
+    - scraps
 - Honey Glazed Carrots 
-	- Carrots
-	- Honey
-	- Dandelion
+    - Carrots
+    - Honey
+    - Dandelion
 - Kabobs
-	- Raw meat
-	- Bone fragments
-	- Carrot
-	- Turnip
+    - Raw meat
+    - Bone fragments
+    - Carrot
+    - Turnip
 - Ice Cream Cone
-	- freeze gland
-	- drake egg
-	- Honey
-	- blueberry
+    - freeze gland
+    - drake egg
+    - Honey
+    - blueberry
 - Country Fried Lox Meat
-	- lox meat
-	- butter
-	- barley flour
-	- egg (new seagull drop)
+    - lox meat
+    - butter
+    - barley flour
+    - egg (new seagull drop)
 
 
 ### v. 1.1.0
 
 - Smoked Fish
-	- raw fish
+    - raw fish
 
 #### Food Menu Assets Courtesy of zarboz
 
 - Bacon
     - raw pork
 - Coffee
-	- ancient seeds
+    - ancient seeds
 - Pizza
-	- mushroom
-	- flour
-	- egg
-	- raw meat
+    - mushroom
+    - flour
+    - egg
+    - raw meat
 - Pancakes
-	- flour
-	- egg
-	- honey
-	- butter
+    - flour
+    - egg
+    - honey
+    - butter
 
 
 ### v. 2.0.0
 
 - Porridge
-	- barley
-	- cloudberry
-	- honey
-	- butter
+    - barley
+    - cloudberry
+    - honey
+    - butter
 - Fire cream cone
-	- SurtlingCore
-	- Raspberry
-	- honey
-	- drake egg
+    - SurtlingCore
+    - Raspberry
+    - honey
+    - drake egg
 - Electric cream cone
-	- Crystal
-	- Cloudberry
-	- Honey
-	- drake egg
+    - Crystal
+    - Cloudberry
+    - Honey
+    - drake egg
 - Acid cream cone
-	- Guck
-	- MushroomYellow
-	- Honey
-	- drake egg
+    - Guck
+    - MushroomYellow
+    - Honey
+    - drake egg
 - PBJ
-	- Queens Jam
-	- Bread
-	- Nut-ella
+    - Queens Jam
+    - Bread
+    - Nut-ella
 - Cake
-	- egg
-	- flour
-	- cloud berry
-	- honey
+    - egg
+    - flour
+    - cloud berry
+    - honey
 
 
 ### v. 3.0.0
 
 - Haggis
-	- entrails
-	- raw meat
-	- carrot
-	- turnip
+    - entrails
+    - raw meat
+    - carrot
+    - turnip
 - Moochi
-	- freeze gland
-	- blueberry
-	- drake egg
-	- honey
+    - freeze gland
+    - blueberry
+    - drake egg
+    - honey
 - Candied Turnips
-	- honey
-	- turnip
-	- thistle
+    - honey
+    - turnip
+    - thistle
 - Boiled Eggs
-	- eggs
+    - eggs
 - Carrot Sticks
-	- carrots
-	- nut-ella
+    - carrots
+    - nut-ella
 
 
 ### Master Chef2.0 Assets
 
 - Omlette
-	- egg
-	- raw pork
-	- thistle
-	- butter
+    - egg
+    - raw pork
+    - thistle
+    - butter
 - Broth
-	- bone fragments
-	- butter
+    - bone fragments
+    - butter
 - Butter
-	- carrot seeds
+    - carrot seeds
 - Fish Stew
-	- raw fish
-	- broth
-	- thistle
-	- egg
+    - raw fish
+    - broth
+    - thistle
+    - egg
 - Burger
-	- raw lox meat
-	- raw meat
-	- bread
-	- turnip
+    - raw lox meat
+    - raw meat
+    - bread
+    - turnip
 - Bloodsausage
-	- entrails
-	- raw pork
-	- thistle
-	- blood bag
+    - entrails
+    - raw pork
+    - thistle
+    - blood bag
 - Nut-ella
-	- Beech Seeds
-	- butter
+    - Beech Seeds
+    - butter
 
 
 ## Cooking Stations by unlock
@@ -225,9 +241,14 @@ Oven | Addon for grill (Grill level +1) <br> Surtling Cores, and Trophies
 - [x] add new food drops from creatures
 - [ ] meals (delayed until H&H)
 - [x] config sync
+- [ ] Add Cooking Skill Sprite Graphic
 
 This mod is routinely tested on a dedicated server with a great many other mods. To ensure your crafting stations don't disappear, and that food doesn't turn to dust, please put this on the dedicated server as well as ALL clients.
 
 ## Credits
-Huge thanks to zarboz, GraveBear, and plumga for helping me get going, setting me up, and encouraging me the whole way! This mod wouldn't exist without them.
-Also a big thanks to my "players" on my server (my husband and our good friend) Itsmesds, and JaxomFaux who've helped with ideas and balance from the start. (Bone Appetit's name came from us haning out when itmesds said how about "bone appetit" and it stuck)
+Huge thanks to zarboz, GraveBear, and plumga for helping me get going, setting me up, and encouraging me the whole way! This mod wouldn't exist without them.  
+
+Also a big thanks to my "players" on my server (my husband and our good friend) Itsmesds, and JaxomFaux who've helped with ideas and balance from the start. (Bone Appetit's name came from us haning out when itmesds said how about "bone appetit" and it stuck)  
+
+Cooking Skill added by [Digitalroot](https://github.com/Digitalroot)
+


### PR DESCRIPTION
[Added Cooking Skill]
Gain XP when cooking at a Cooking Station, or cooking a Consumable at the rk_griddle, rk_grill, rk_prep or piece_cauldron. Each level of cooking skill adds a 1% chance to craft an additional consumable. after lvl 25, your total cooking level is divided by 4 and the results is the % chance to crafted a 2nd additional consumable.

e.g. At level 100, there is a 100% chance to craft an additional consumable and 25% chance to craft a 2nd additional consumable on top of that. At level 100 a food that crafts in stacks of x5, if lucky could output 7 total items.

Set CookingSkillEnable = false to disable.

[Added SE_CheffHat]
Improves Cooking Skill XP Earned while wearing the Chef Hat. Set HatXpGain = 1 to disable.

Taking the Chef Hat on and off displays a random Julia Child's quote. Displaying this message can be disabled by setting HatSEMessage to false.

[Added Configs]
- CookingSkillEnable (server synced, enforced)
- BonusWhenCookingEnabled (server synced, enforced)
- HatXpGain (server synced, enforced)
- HatSEMessage (local)

[Other]
- Update Mod Version to 3.1.0
- Updated NuGet packages
- Added NexusId for update notice
- Added Debug Logging for DEBUG builds
- Added Harmony Patches for Inventory.AddItem and CookingStation.CookItem
- Update ReadMe

[ToDo]
- Cooking Skill needs a Sprite Graphic